### PR TITLE
CHANGELOG 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,23 @@
+CHANGELOG 1.3
+- Fixed display_after_message() to show $selected_interface
+- Fixed random bash best practices based on ShellCheck
+- Did some README.md fixes
+- Simplified the die() function
+- Removed useless calls for usage() all over the script
+- Added absolute paths for commands such as ip, tc, ping, modprobe etc.
+- Added kmod as a dependency
+- Added version info in die()
+- Changed the location of cleanup for numeric values to the parse_arguments()
+- Fixed the validation for validate_numeric_format()
+- Fixed the validation for validate_ip_format()regex for the IPv4 validation / Removed IPv6 validation for now
+- Added rollback_everything if rollback_required=1 during die()
+
 CHANGELOG 1.2
 - Added variable versioning
 - Added jitter for both
-- Fixed splitting latency and jitter to suppoer factorials so / 2 = 0.*
+- Fixed splitting latency and jitter to support factorials so / 2 = 0.*
 - Changed default direction to 'both' instead of 'egress'
-- Enabled multiple --dst_ip using a -d 192.168.1.100,192.168.1.103, 192.168.101.0/24 format
+- Enabled multiple --dst_ip using a -d 192.168.1.100,192.168.1.103,she192.168.101.0/24 format
 - Enhanced usage()
 - Other general enhancements
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ Latency Ninja is a wrapper tool built around `tc/netem`, designed to empower you
 
 ## Key Features
 
-- 🕒 Latency: Control network delay, enabling you to mimic real-world scenarios with adjustable latency settings.
-- 🔄 Jitter: Introduce variability to latency, replicating the unpredictable nature of network traffic.
-- 💥 Corruption: Corrupt a defined percentage of packets to assess network and application resilience.
-- ✨ Duplication: Duplicate packets to evaluate network performance under data replication scenarios.
-- 🔀 Reordering: Test how your applications handle out-of-sequence packets with customizable reordering.
-- 📦 Packet Loss: Simulate packet loss, a crucial factor in assessing application robustness.
-- 📥 Ingress Traffic: Apply conditions to incoming traffic.
-- 📤 Egress Traffic: Apply conditions to outgoing traffic.
-- 📥 📤 Both Ingress and Egress Traffic: Apply conditions to both incoming and outgoing traffic for comprehensive (real life) testing.
-- 🎯 Target Destination IP/Network: Specify the destination IP address or network to apply traffic conditions.
-- 🎯 Target Source IP/Network: Specify the source IP address or network to apply traffic conditions.
+* 🕒 Latency: Control network delay, enabling you to mimic real-world scenarios with adjustable latency settings.
+* 🔄 Jitter: Introduce variability to latency, replicating the unpredictable nature of network traffic.
+* 💥 Corruption: Corrupt a defined percentage of packets to assess network and application resilience.
+* ✨ Duplication: Duplicate packets to evaluate network performance under data replication scenarios.
+* 🔀 Reordering: Test how your applications handle out-of-sequence packets with customizable reordering.
+* 👻 Packet Loss: Simulate packet loss, a crucial factor in assessing application robustness.
+* 🧭 Direction: Apply conditions to both incoming and outgoing traffic for comprehensive real-world testing. 
+  * 📥 Ingress and 📤 Egress: Apply conditions to both incoming and outgoing traffic simultenaously. 
+  * 📥 Ingress Traffic Only: Apply conditions to incoming traffic.
+  * 📤 Egress Traffic Only: Apply conditions to outgoing traffic.
+* 🎯 Target Multiple Destination IP/Networks: Specify the destination IP addresses or networks.
+* 🌍 Filter by Source IP/Network: Specify the source IP address or network.
 
 ## Compatibility
 
@@ -49,26 +50,26 @@ Latency Ninja is compatible with Red Hat/CentOS/Fedora/Debian/Ubuntu Linux-based
         
     Usage: $0 -i <interface> -d <destination> [OPTIONS]
     
-    Options:"
-      -h, --help                              Display this help message."
-      -r, --rollback                          Rollback any networking conditions changes and redirections."
+    Options:
+      -h, --help                              Display this help message.
+      -r, --rollback                          Rollback any networking conditions changes and redirections.
     
-    Required Parameters:"    
-      -i, --interface <interface>             Network interface (e.g., eth0)."
-      -d, --dst_ip <ip1[,ip2,ip3...]>         Destination IP(s) / Network(s) (e.g. 192.168.1.100,192.168.1.102,192.168.1.103)."    
+    Required Parameters:    
+      -i, --interface <interface>             Network interface (e.g., eth0).
+      -d, --dst_ip <ip1[,ip2,ip3...]>         Destination IP(s) / Network(s) (e.g. 192.168.1.100,192.168.1.102,192.168.1.103).    
     
-    Optional Parameters:"
-      -s, --src_ip <source_ip>                Source IP / Network (default: IP of selected interface)."
-      -w, --direction <direction>             Desired direction of the networking conditions (e.g., ingress, egress, or both) (default: both)."
-      -p, --pings <num_pings>                 Desired number of pings to test (default: 5)."  
+    Optional Parameters:
+      -s, --src_ip <source_ip>                Source IP / Network (default: IP of selected interface).
+      -w, --direction <direction>             Desired direction of the networking conditions (e.g., ingress, egress, or both) (default: both).
+      -p, --pings <num_pings>                 Desired number of pings to test (default: 5).  
     
-    Network Conditions:"    
-      -l, --latency <latency>                 Desired latency in milliseconds (e.g., 30 for 30ms)."
-      -j, --jitter <jitter>                   Desired jitter in milliseconds (e.g., 3 for 3ms). Use with -l|--latency only."
-      -x, --packet-loss <packet_loss>         Desired packet loss percentage (e.g., 2 for 2% or 0.9 for 0.9%)."    
-      -y, --duplicate <duplicate>             Desired duplicate packet percentage (e.g., 2 for 2% or 0.9 for 0.9%)."
-      -z, --corrupt <corrupt>                 Desired corrupted packet percentage (e.g., 2 for 2% or 0.9 for 0.9%)."
-      -k, --reorder <reorder>                 Desired packet reordering percentage (e.g., 2 for 2% or 0.9 for 0.9%)."
+    Network Conditions:    
+      -l, --latency <latency>                 Desired latency in milliseconds (e.g., 30 for 30ms).
+      -j, --jitter <jitter>                   Desired jitter in milliseconds (e.g., 3 for 3ms). Use with -l|--latency only.
+      -x, --packet-loss <packet_loss>         Desired packet loss percentage (e.g., 2 for 2% or 0.9 for 0.9%).    
+      -y, --duplicate <duplicate>             Desired duplicate packet percentage (e.g., 2 for 2% or 0.9 for 0.9%).
+      -z, --corrupt <corrupt>                 Desired corrupted packet percentage (e.g., 2 for 2% or 0.9 for 0.9%).
+      -k, --reorder <reorder>                 Desired packet reordering percentage (e.g., 2 for 2% or 0.9 for 0.9%).
     
 ## Example
 To simulate 100ms latency, 10ms jitter, and 5% packet loss on the eth0 interface for traffic going to 192.168.1.10, run:
@@ -94,7 +95,7 @@ To roll back previously applied network perturbations, run:
 
 ## Roadmap
 - Persist network perturbations policies after network interface restart and reboots.
-- Schedule rollback.
+- Schedule rollbacks.
 - Auto download dependencies.
 - Add traffic shaping capabilities.
 
@@ -103,5 +104,3 @@ We welcome contributions! If you'd like to contribute, please create a pull requ
 
 ## License
 This project is licensed under the GNU General Public License v2.0. Please refer to the LICENSE file for more details.
-
-


### PR DESCRIPTION
- Fixed display_after_message() to show $selected_interface
- Fixed random bash best practices based on ShellCheck
- Did some README.md fixes
- Simplified the die() function
- Removed useless calls for usage() all over the script
- Added absolute paths for commands such as ip, tc, ping, modprobe etc.
- Added kmod as a dependency
- Added version info in die()
- Changed the location of cleanup for numeric values to the parse_arguments()
- Fixed the validation for validate_numeric_format()
- Fixed the validation for validate_ip_format()regex for the IPv4 validation / Removed IPv6 validation for now
- Added rollback_everything if rollback_required=1 during die()