### PR TITLE
CHANGELOG 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+CHANGELOG 1.4
+- Clearified some documentation in usage() and in the README.
+- Changed packet-loss to packet_loss
+- Renamed validate_numeric_format() to validate_numeric
+- Renamed validate_ip_format() to validate_ip()
+- Created validate_test_method() to check if the test is icmp or http
+- Refactored the ping_destination() and extracted is_single_host() to it can be tested for ping/icmp and curl/http
+- Replaced all pinging() and ping* related functions with test_destination() that allow for both icmp/ping and curl/http
+- Added curl as a dependency for http testing
+- Changed $selected_interface to $interface
+- Reformated the ping output and made a new way of outputing icmp/ping and curl/http tests
+- Replaced -p with -c (test_counts) and -t (test_methods)
+- Enhanced create_virtual_interface()
+- Enhanced rollback_everything()
+- Fixed all instances of delete_qdisc_if_exists() which had wrong handles causing disconnections
+
 CHANGELOG 1.3
 - Fixed display_after_message() to show $selected_interface
 - Fixed random bash best practices based on ShellCheck

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Latency Ninja is compatible with Red Hat/CentOS/Fedora/Debian/Ubuntu Linux-based
     git clone https://github.com/haythamelkhoja/latencyninja
     cd latencyninja
     chmod +x ./latencyninja.sh    
-    ./latencyninja.sh -h
+    ./latencyninja.sh --help
 
  ## Usage
         
-    Usage: $0 -i <interface> -d <destination> [OPTIONS]
+    Usage: -i <interface> -d <destination> [OPTIONS]
     
     Options:
       -h, --help                              Display this help message.
@@ -72,10 +72,14 @@ Latency Ninja is compatible with Red Hat/CentOS/Fedora/Debian/Ubuntu Linux-based
       -k, --reorder <reorder>                 Desired packet reordering percentage (e.g., 2 for 2% or 0.9 for 0.9%).
     
 ## Example
-To simulate 100ms latency, 10ms jitter, and 5% packet loss on the eth0 interface for traffic going to 192.168.1.10, run:
+To simulate 100ms latency, 1.3ms jitter, and 5% packet loss on the eth0 interface for traffic going to 192.168.1.10, run:
 
-    ./latencyninja.sh -i eth0 -d 192.168.1.10 -l 100 -j 1.3 -x 5
-    
+    ./latencyninja.sh \
+            --interface eth0 \
+            --destination 192.168.1.10 \
+            --latency 100 \
+            --jitter 1.3 \
+            --packet-loss 5   
 
 To roll back previously applied network perturbations, run:
 

--- a/testing_samples.txt
+++ b/testing_samples.txt
@@ -1,0 +1,10 @@
+./latencyninja.sh --interface ens192 \
+                                    --dst_ip 192.168.100.104 \
+                                    --latency 400 \
+                                    --jitter 1 \
+                                    --corrupt 0.2 \
+                                    --duplicate 0.1 \
+                                    --reorder 0.1 \
+                                    --test_method http \
+                                    --test_count 3
+


### PR DESCRIPTION
- Clearified some documentation in usage() and in the README.
- Changed packet-loss to packet_loss
- Renamed validate_numeric_format() to validate_numeric
- Renamed validate_ip_format() to validate_ip()
- Created validate_test_method() to check if the test is icmp or http
- Refactored the ping_destination() and extracted is_single_host() to it can be tested for ping/icmp and curl/http
- Replaced all pinging() and ping* related functions with test_destination() that allow for both icmp/ping and curl/http
- Added curl as a dependency for http testing
- Changed $selected_interface to $interface
- Reformated the ping output and made a new way of outputing icmp/ping and curl/http tests
- Replaced -p with -c (test_counts) and -t (test_methods)
- Enhanced create_virtual_interface()
- Enhanced rollback_everything()
- Fixed all instances of delete_qdisc_if_exists() which had wrong handles causing disconnections